### PR TITLE
关于自定义优化段的移除

### DIFF
--- a/spark-dwine-helper/s-wine-helper/deepinwine/tools/spark_run_v4.sh
+++ b/spark-dwine-helper/s-wine-helper/deepinwine/tools/spark_run_v4.sh
@@ -422,7 +422,7 @@ CallApp()
     debug_log "CallApp $BOTTLENAME arg count $#: $*"
 
     case $BOTTLENAME in
-        "Deepin-WangWang"|"AliIm-taobao")
+        "Deepin-WangWang")
             CallWangWang "$@"
             ;;
         "Deepin-ZhuMu")

--- a/spark-dwine-launch/run-template_v1.sh
+++ b/spark-dwine-launch/run-template_v1.sh
@@ -81,6 +81,13 @@ export WINEDLLOVERRIDES="mscoree,mshtml="
 echo "为了降低打包体积，默认关闭gecko和momo，如有需要，注释此行（仅对spark-wine7-devel有效）"
 
 fi
+#####################################
+if [ "$APPRUN_CMD" = "ukylin-wine" ];then
+
+export WINEDLLOVERRIDES="mscoree,mshtml="
+echo "同上，修正ukylin-wine"
+
+fi
 ##############>>>>>>>>>屏蔽mono和gecko安装器结束
 
 #########################执行段


### PR DESCRIPTION
由于阿里旺旺的相应优化段与版本号有极大的联系，也就是说版本一升级，就要在此处改版本号，所以旺旺10不打算走此优化段，取而代之的是由打包者编写优化段。